### PR TITLE
Security audit V2: fix XSS, add CSP, harden rules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
           echo "VITE_FIREBASE_STORAGE_BUCKET=${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}" >> .env.local
           echo "VITE_FIREBASE_MESSAGING_SENDER_ID=${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}" >> .env.local
           echo "VITE_FIREBASE_APP_ID=${{ secrets.VITE_FIREBASE_APP_ID }}" >> .env.local
+          echo "VITE_ADMIN_EMAIL=${{ secrets.VITE_ADMIN_EMAIL }}" >> .env.local
       - run: npm run build
       - run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.env
+.env.*
 *.local
 
 # Generated import data

--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -137,3 +137,278 @@ Firebase API keys are intentionally public (they identify the project, not grant
 7. ~~SRI~~ — `vite-plugin-sri-gen` adds integrity hashes at build time
 8. ~~security.txt~~ — added at `public/.well-known/security.txt`
 9. ~~Ownership bypass~~ — `overwriteCrossword()` always stamps current auth user
+
+---
+---
+
+# V2 — Security Audit (2026-04-08)
+
+**Date:** 2026-04-08
+**Scope:** Full client-side codebase re-audit + Firestore security rules review
+**Threat model:** Small group of known creators (~6 users), public anonymous solvers, potential growth. Admin: `yonatanm@gmail.com`.
+
+## Executive Summary
+
+V1 fixed the critical issues well. This V2 audit found a **residual XSS** in the same print function (missed fields), a **missing CSP on the print window** that amplifies it, and several Firestore rule gaps. The rules are solid overall but have one meaningful hole in the update path.
+
+| Severity | Found |
+|----------|-------|
+| High     | 2     |
+| Medium   | 5     |
+| Low      | 3     |
+
+---
+
+## High
+
+### ~~H1. Residual Stored XSS in Print — Cell Letters & Position Labels Not Escaped~~ — FIXED
+
+**File:** `src/lib/print-crossword.ts` lines 137–141
+
+V1 audit (#1) fixed XSS for `title`, `description`, and `clue` text by applying `escapeHtml()`. However, **two fields were missed**:
+
+```typescript
+const letter = isHighlighted && cell.letter ? cell.letter : ""
+gridHtml += `<td class="cell${isHighlighted ? " hint" : ""}">
+  ${letter}                                         // ← NOT ESCAPED
+  ${label != null ? `<span class="num">${label}</span>` : ""}  // ← NOT ESCAPED
+</td>`
+```
+
+- `cell.letter` comes from the grid (stored as JSON string in Firestore)
+- `label` comes from `word?.position` in `layout_result` (also stored as JSON in Firestore)
+
+**Amplifier:** The print window is opened via `window.open("") + document.write()` (line 322–325). The generated HTML (lines 201–320) contains **no CSP meta tag**. The parent page's CSP does not inherit to `about:blank` windows populated via `document.write()`. This means any injected script executes without restriction.
+
+**Attack scenario:**
+1. Authenticated user creates a crossword normally
+2. Using Firebase SDK directly (browser console), attacker updates their own crossword's `grid` JSON to include `cell.letter = '<img src=x onerror="...">'`
+3. Attacker publishes the crossword
+4. Admin (who sees all crosswords) opens it in the editor and clicks Print
+5. XSS payload fires in a window with zero CSP — full DOM access, can read cookies, call Firebase APIs as admin
+
+**Fix:**
+- Apply `escapeHtml()` to both `letter` and `label` before HTML interpolation
+- Add a CSP `<meta>` tag to the print window HTML (at minimum: `script-src 'none'` after the `window.print()` call, or `script-src 'unsafe-inline'` to allow the print trigger only)
+
+---
+
+### ~~H2. Firestore Security Rules Not Version-Controlled~~ — FIXED
+
+There is no `firestore.rules` file and no `firebase.json` in the repository. The security rules exist only in the Firebase Console.
+
+**Risks:**
+- Rules cannot be code-reviewed in PRs
+- No audit trail for rule changes
+- Rules can drift from documented behavior without anyone noticing
+- No CI/CD validation or testing of rules
+- If the Firebase project is recreated or transferred, rules are lost
+
+**Fix:**
+- Add `firestore.rules` to the repo root (copy from Firebase Console)
+- Add `firebase.json` pointing to the rules file
+- Optionally: add `firebase deploy --only firestore:rules` to CI pipeline
+
+---
+
+## Medium
+
+### M1. Admin Email Exposed in Production Bundle + Hardcoded in Firestore Rules
+
+**Files:**
+- `src/hooks/useAuth.ts` line 8 — `VITE_ADMIN_EMAIL` compiled into JS bundle
+- Firestore rules `isAdmin()` function — hardcoded `'yonatanm@gmail.com'`
+
+The admin email `yonatanm@gmail.com` is visible to anyone who inspects the production JavaScript bundle (e.g., via browser DevTools → Sources). An attacker now knows the exact Google account that grants admin access.
+
+**Risk:** Targeted phishing or credential stuffing against the admin account. Firebase Auth relies on Google's authentication — if the Google account is compromised, the attacker gets full admin access (read all crosswords, update/delete any document).
+
+**Mitigation context:** This is a known limitation of client-side-only apps without a backend. Firebase custom claims (the proper solution) require a server/Cloud Function. The V1 audit noted this and accepted the trade-off, which is reasonable for the current threat model.
+
+**Recommendation:** Ensure the admin Google account has strong 2FA enabled. Consider using a dedicated service account email rather than a personal email if the app grows.
+
+---
+
+### ~~M2. Firestore Update Rule Doesn't Enforce `userId` Preservation~~ — FIXED (in repo, needs deploy)
+
+**File:** Firestore security rules (not in repo — currently in Firebase Console only)
+
+Current update rule:
+```
+allow update: if (isOwner() || isAdmin())
+              && request.resource.data.title.size() < 200
+              && request.resource.data.keys().size() < 30;
+```
+
+The rule validates that the **current** document owner (or admin) is making the update, but does **not** validate that the **new** document preserves the same `userId`.
+
+**Attack scenarios:**
+1. **Ownership transfer:** Owner updates their own document, changing `userId` to another user's UID. That other user now "owns" it and can modify/delete it.
+2. **Orphaning via race condition:** `overwriteCrossword()` (firestore.ts:87) uses `setDoc()` with `userId: user?.uid`. If `auth.currentUser` is null at call time (e.g., user logged out between auto-save trigger and execution), `userId` becomes `undefined`, Firebase SDK strips it, and the document loses its owner. Nobody can read/update it except admin.
+
+**Fix:** Add to the update rule:
+```
+&& request.resource.data.userId == resource.data.userId
+```
+
+This ensures `userId` cannot be changed on update, preventing both ownership transfer and orphaning.
+
+---
+
+### ~~M3. `overwriteCrossword()` Uses `setDoc()` — Silently Drops `createdAt`~~ — FIXED
+
+**File:** `src/lib/firestore.ts` line 87
+
+`setDoc()` **replaces** the entire Firestore document (not a merge). The EditorPage auto-save builds its data object (EditorPage.tsx lines 396–421) but does **not** include `createdAt`. This means every auto-save deletes the original creation timestamp.
+
+**Impact:** Data integrity issue. All crosswords appear to have no creation date. Not a security vulnerability per se, but unexpected data loss.
+
+**Fix options:**
+- Include `createdAt: existingCrossword?.createdAt` in the auto-save data object
+- Or use `setDoc(docRef, data, { merge: true })` to preserve unspecified fields
+- Or switch from `setDoc` to `updateDoc` for overwrites (only writes specified fields)
+
+---
+
+### ~~M4. CSP Weaknesses~~ — PARTIALLY FIXED
+
+**File:** `index.html` line 7
+
+Current CSP has three weaknesses:
+
+| Directive | Issue |
+|-----------|-------|
+| `style-src 'unsafe-inline'` | Allows CSS injection attacks (e.g., data exfiltration via `background: url(...)` with user-controlled style attributes) |
+| `img-src data:` | Allows data URI images, which can be used for data exfiltration in combination with CSS injection |
+| `connect-src ws://localhost:*` | Development WebSocket endpoint included in production CSP — unnecessary attack surface |
+
+Additionally, the **print window has zero CSP** (see H1). Any future print-related XSS is automatically fully exploitable.
+
+**Fix:**
+- Remove `ws://localhost:*` from `connect-src` (or conditionally include only in dev)
+- Consider removing `data:` from `img-src` if not needed
+- `'unsafe-inline'` in `style-src` is hard to remove with Tailwind CSS — this is a known trade-off, acceptable given no user-controlled style attributes exist in the app
+
+---
+
+### ~~M5. `repairMissingUserIds()` — Dead Code, Overprivileged~~ — FIXED
+
+**File:** `src/lib/firestore.ts` lines 143–162
+
+```typescript
+export async function repairMissingUserIds(): Promise<number> {
+  const user = auth.currentUser
+  if (!user) return 0
+  const snapshot = await getDocs(collection(db, COLLECTION))  // ALL documents
+  for (const d of snapshot.docs) {
+    if (!data.userId) {
+      await updateDoc(doc(db, COLLECTION, d.id), { userId: user.uid, ... })
+    }
+  }
+}
+```
+
+This function is **never called** anywhere in the application. It fetches all documents and claims ownership of any with missing `userId`.
+
+**Firestore rules partially mitigate this:** A non-admin user's `getDocs()` call would only return documents they own or that are published. For published documents, the update would fail (not owner, not admin). So in practice, this function is a no-op for non-admin users.
+
+For admin: it works as intended but represents unnecessary attack surface.
+
+**Fix:** Delete the function. If one-time repairs are needed in the future, run them via the Firebase Console or a dedicated admin script.
+
+---
+
+## Low
+
+### L1. GitHub Actions Not SHA-Pinned
+
+**File:** `.github/workflows/deploy.yml` lines 21, 22, 38, 50
+
+All GitHub Actions use major version tags (`@v4`, `@v3`) instead of commit SHAs:
+```yaml
+- uses: actions/checkout@v4        # should be @<commit-sha>
+- uses: actions/setup-node@v4
+- uses: actions/upload-pages-artifact@v3
+- uses: actions/deploy-pages@v4
+```
+
+If an action maintainer's account is compromised, the attacker could push malicious code under the same version tag. Pinning to commit SHAs prevents this.
+
+**Risk:** Low probability, but high impact (full access to repo secrets during build).
+
+---
+
+### ~~L2. `.gitignore` Incomplete for `.env` Patterns~~ — FIXED
+
+**File:** `.gitignore` line 13
+
+Current pattern `*.local` covers `.env.local` but **not**:
+- `.env`
+- `.env.production`
+- `.env.development`
+- `.env.staging`
+
+**Risk:** Accidental commit of a non-`.local` env file could expose secrets.
+
+**Fix:** Add explicit entries:
+```
+.env
+.env.*
+!.env.example
+```
+
+---
+
+### L3. Firestore Rules: Hardcoded Admin Email (No Alternative)
+
+The `isAdmin()` function in Firestore rules uses a literal email string. If the admin email changes, both the client code (`VITE_ADMIN_EMAIL`) and Firestore rules need manual updates in two different places.
+
+This is a known limitation of client-side-only Firebase apps. The proper solution (Firebase custom claims) requires a backend/Cloud Function, which is out of scope for this project's architecture.
+
+**No action required** — documented for awareness.
+
+---
+
+## Firestore Rules Review
+
+Rules reviewed from Firebase Console (saved to `/tmp/fb-rukes.txt`).
+
+### What's Done Well
+
+- Published crosswords readable without auth (solve page works) ✓
+- Drafts restricted to owner + admin ✓
+- Create enforces `request.resource.data.userId == request.auth.uid` ✓
+- Input validation: `title.size() < 200`, `keys().size() < 30` ✓
+- Update/delete restricted to owner or admin ✓
+- Default deny for all other paths ✓
+- `isOwner()` and `isAdmin()` helper functions properly check `request.auth != null`
+
+### Gaps
+
+| Gap | Severity | Fix |
+|-----|----------|-----|
+| Update doesn't enforce `userId` preservation | Medium (M2) | Add `request.resource.data.userId == resource.data.userId` |
+| No validation on `status` field values | Low | Add `request.resource.data.status in ['draft', 'published', 'archived']` |
+| No rate limiting on creates | Low | Hard to enforce in Firestore rules alone — consider Cloud Functions if abuse occurs |
+| Admin email hardcoded | Low (L3) | No alternative without backend |
+
+---
+
+## Recommended Action Plan (Prioritized)
+
+### Priority 1 — Fix Now
+1. **Escape `cell.letter` and `label`** in `print-crossword.ts:137-141` with `escapeHtml()`
+2. **Add CSP meta tag** to print window HTML
+3. **Add `userId` preservation check** to Firestore update rule
+4. **Add `firestore.rules`** to the repo
+
+### Priority 2 — Soon
+5. **Fix `createdAt` loss** — include it in `overwriteCrossword()` data or switch to `updateDoc`
+6. **Remove `repairMissingUserIds()`** dead code
+7. **Remove `ws://localhost:*`** from production CSP
+8. **Expand `.gitignore`** to cover all `.env` patterns
+
+### Priority 3 — When Convenient
+9. Pin GitHub Actions to commit SHAs
+10. Add `status` field validation to Firestore update rule
+11. Enable 2FA on admin Google account if not already

--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -1,0 +1,139 @@
+# Security Audit Report — tashbetzim.co.il
+
+**Date:** 2026-04-05
+**Scope:** Full client-side codebase, dependencies, build pipeline, Firebase integration
+**Hosted on:** GitHub Pages (static SPA) + Firebase (auth + Firestore)
+
+---
+
+## Executive Summary
+
+The application is a client-side React SPA with Firebase backend. The main attack surface is: user-generated content rendered without sanitization (XSS in print), missing Firestore security rules (authorization bypass), and vulnerable transitive dependencies. No secrets are leaked in git.
+
+| Severity | Found | Fixed |
+|----------|-------|-------|
+| Critical | 2 | 2 |
+| High | 3 | 3 |
+| Medium | 4 | 4 |
+| Low | 3 | 1 |
+
+---
+
+## Critical
+
+### ~~1. Stored XSS via Print Functionality~~ — FIXED
+
+**File:** `src/lib/print-crossword.ts`
+
+~~User-supplied `title`, `description`, and `clue` text were interpolated directly into HTML via `document.write()` without escaping.~~
+
+**Status:** Fixed — all user content now passes through `escapeHtml()` before HTML interpolation.
+
+---
+
+### ~~2. No Firestore Security Rules~~ — FIXED
+
+**Status:** Firestore rules now deployed with proper ownership enforcement:
+- Published crosswords readable by anyone
+- Drafts readable only by owner or admin
+- Create requires `userId == auth.uid`
+- Update/delete restricted to owner or admin
+- No wildcard write access
+
+---
+
+## High
+
+### ~~3. No Ownership Validation in Write Operations~~ — FIXED
+
+**Status:** `overwriteCrossword()` now strips caller-supplied ownership fields and always stamps `auth.currentUser`. Firestore rules also enforce `request.resource.data.userId == request.auth.uid` on create and owner-only update/delete.
+
+---
+
+### ~~4. Hardcoded Admin UID Exposed in Bundle~~ — FIXED
+
+**Status:** Admin UID moved from hardcoded string to `VITE_ADMIN_UID` env var (GitHub secret set). Client-side `isAdmin` is UI-only; actual admin authorization enforced by Firestore rules `isAdmin()` function. Without a backend, Firebase custom claims are not feasible — current approach is appropriate.
+
+---
+
+### ~~5. Seven Vulnerable npm Dependencies~~ — FIXED
+
+**Status:** `npm audit fix` applied — 0 vulnerabilities remaining.
+
+---
+
+## Medium
+
+### ~~6. No Content-Security-Policy~~ — FIXED
+
+**Status:** CSP `<meta>` tag added to `index.html` with `script-src 'self'`, restricted `connect-src` for Firebase, and `frame-ancestors 'none'`.
+
+---
+
+### ~~7. No Clickjacking Protection~~ — FIXED
+
+**Status:** `frame-ancestors 'none'` included in the CSP meta tag.
+
+---
+
+### ~~8. No Input Length or Content Validation~~ — FIXED
+
+**Status:** Firestore rules now enforce `title.size() < 200` and `keys().size() < 30` on create and update.
+
+---
+
+### ~~9. Missing Subresource Integrity (SRI) on Production Assets~~ — FIXED
+
+**Status:** `vite-plugin-sri-gen` added to build pipeline. Production assets now include `integrity="sha384-..."` hashes.
+
+---
+
+## Low
+
+### 10. `allowedHosts: true` in Vite Dev Server
+
+**File:** `vite.config.ts` line 18
+
+Disables host header validation in development. Not a production risk (dev server isn't deployed), but could allow DNS rebinding attacks during local development.
+
+---
+
+### 11. No `security.txt`
+
+No `/.well-known/security.txt` file. This is a best practice (RFC 9116) for responsible disclosure.
+
+---
+
+### 12. Firebase API Keys in Client Bundle
+
+Firebase API keys are intentionally public (they identify the project, not grant access). Security depends entirely on Firestore rules (#2). This is noted for awareness — **not a vulnerability if rules are properly configured**, but a critical vulnerability amplifier if rules are missing.
+
+---
+
+## What's Done Well
+
+- `.env.local` is properly gitignored and **not committed** to the repository
+- GitHub Actions workflow uses GitHub Secrets correctly for build-time injection
+- No `eval()`, `Function()`, or dynamic code execution anywhere
+- No `dangerouslySetInnerHTML` in React components — all React rendering is auto-escaped
+- TypeScript strict mode fully enabled (strict, noUnusedLocals, noUnusedParameters)
+- No source maps in production build
+- No test files or dev artifacts in production output
+- GitHub Actions uses pinned major versions (v3/v4) with minimal permissions
+- Firebase modular SDK (tree-shakeable, smaller attack surface than compat)
+- `ClueEditor.tsx` correctly uses `textContent` / `createTextNode()` instead of `innerHTML`
+
+---
+
+## Recommended Action Plan
+
+### All resolved
+1. ~~Fix XSS in print~~ — `escapeHtml()` applied to all user content
+2. ~~Deploy Firestore security rules~~ — ownership enforcement + input size limits active
+3. ~~Run `npm audit fix`~~ — 0 vulnerabilities
+4. ~~Add CSP + clickjacking protection~~ — meta tag with `frame-ancestors 'none'`
+5. ~~Input validation~~ — Firestore rules enforce title size < 200, max 30 fields
+6. ~~Admin UID~~ — moved to `VITE_ADMIN_UID` env var; Firestore rules enforce server-side
+7. ~~SRI~~ — `vite-plugin-sri-gen` adds integrity hashes at build time
+8. ~~security.txt~~ — added at `public/.well-known/security.txt`
+9. ~~Ownership bypass~~ — `overwriteCrossword()` always stamps current auth user

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,39 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isOwner() {
+      return request.auth != null
+          && resource.data.userId == request.auth.uid;
+    }
+
+    function isAdmin() {
+      return request.auth != null
+          && request.auth.token.email == 'yonatanm@gmail.com';
+    }
+
+    match /crossword/{docId} {
+      // Anyone can read published crosswords (solve page)
+      allow read: if resource.data.status == "published";
+
+      // Owners and admin can read their own drafts
+      allow read: if isOwner() || isAdmin();
+
+      // Any authenticated user can create (must stamp own userId)
+      allow create: if request.auth != null
+                    && request.resource.data.userId == request.auth.uid
+                    && request.resource.data.title.size() < 200
+                    && request.resource.data.keys().size() < 30;
+
+      // Only owner or admin can update/delete
+      // userId must be preserved (prevent ownership transfer/orphaning)
+      allow update: if (isOwner() || isAdmin())
+                    && request.resource.data.userId == resource.data.userId
+                    && request.resource.data.title.size() < 200
+                    && request.resource.data.keys().size() < 30;
+      allow delete: if isOwner() || isAdmin();
+    }
+
+    // Deny everything else by default
+  }
+}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/cw.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://apis.google.com https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; font-src https://fonts.gstatic.com; connect-src https://*.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://accounts.google.com ws://localhost:*; img-src 'self' https: data:; frame-src https://accounts.google.com https://*.firebaseapp.com;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://apis.google.com https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; font-src https://fonts.gstatic.com; connect-src https://*.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://accounts.google.com; img-src 'self' https: data:; frame-src https://accounts.google.com https://*.firebaseapp.com;" />
     <title>אחד מאוזן - בונה תשבצים</title>
     <meta name="description" content="אחד מאוזן מאת יונתן ממן — בנו תשבצים בעברית, שתפו עם חברים ופתרו אונליין.">
     <meta name="keywords" content="אחד מאוזן, תשבץ, תשבצים, יונתן ממן, תשבץ בעברית, בונה תשבצים, התשבצים של ניסו">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/cw.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://apis.google.com https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; font-src https://fonts.gstatic.com; connect-src https://*.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://accounts.google.com ws://localhost:*; img-src 'self' https: data:; frame-src https://accounts.google.com https://*.firebaseapp.com;" />
     <title>אחד מאוזן - בונה תשבצים</title>
     <meta name="description" content="אחד מאוזן מאת יונתן ממן — בנו תשבצים בעברית, שתפו עם חברים ופתרו אונליין.">
     <meta name="keywords" content="אחד מאוזן, תשבץ, תשבצים, יונתן ממן, תשבץ בעברית, בונה תשבצים, התשבצים של ניסו">

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vite-plugin-sri-gen": "^1.3.2"
       }
     },
     "node_modules/@antfu/ni": {
@@ -1829,9 +1830,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "dev": true,
       "engines": {
         "node": ">=18.14.1"
@@ -4303,9 +4304,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4614,9 +4615,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4925,9 +4926,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5522,6 +5523,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -5916,12 +5929,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "dev": true,
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -6188,9 +6201,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "node_modules/formdata-polyfill": {
@@ -6463,9 +6476,9 @@
       "dev": true
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "engines": {
         "node": ">=16.9.0"
@@ -6580,9 +6593,9 @@
       "dev": true
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "engines": {
         "node": ">= 12"
@@ -7321,9 +7334,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -7834,6 +7847,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7879,9 +7904,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "engines": {
         "node": ">=12"
       },
@@ -8440,9 +8465,9 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -9279,9 +9304,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9349,6 +9374,21 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-sri-gen": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-sri-gen/-/vite-plugin-sri-gen-1.3.2.tgz",
+      "integrity": "sha512-/tbM2168Aeiw9jV1+4mzno/ZDMT9aZ2qh+mi10DBlLc+IfuTqn3BFFI6fQS1s6xsfPzhzCRFSoPjP3NrsTvoDQ==",
+      "dev": true,
+      "dependencies": {
+        "parse5": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=4.0.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vite-plugin-sri-gen": "^1.3.2"
   }
 }

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: https://github.com/yonatanm/doublecross/issues
+Expires: 2027-04-05T00:00:00.000Z
+Preferred-Languages: he, en

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,8 +3,9 @@ import type { User } from "firebase/auth"
 import { onAuthStateChanged, signInWithPopup, signOut } from "firebase/auth"
 import { auth, googleProvider } from "@/lib/firebase"
 
-// Must match the UID in Firestore security rules isAdmin()
-const ADMIN_UID = "ksor1EBFKWRAd7whHqX1t2PJDX32"
+// Must match the email in Firestore security rules isAdmin().
+// This is a UI-only gate; actual authorization is enforced by Firestore rules.
+const ADMIN_EMAIL = import.meta.env.VITE_ADMIN_EMAIL || ""
 
 export interface AuthContextValue {
   user: User | null
@@ -44,7 +45,7 @@ export function useAuthProvider(): AuthContextValue {
     await signOut(auth)
   }, [])
 
-  return { user, isLoggedIn: !!user, isAdmin: user?.uid === ADMIN_UID, loading, login, logout }
+  return { user, isLoggedIn: !!user, isAdmin: user?.email === ADMIN_EMAIL, loading, login, logout }
 }
 
 export function useAuth() {

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -78,14 +78,19 @@ export async function updateCrossword(id: string, data: Partial<Crossword>): Pro
 export async function overwriteCrossword(id: string, crossword: Omit<Crossword, "id">): Promise<void> {
   const user = auth.currentUser
   const docRef = doc(db, COLLECTION, id)
+  const serialized = serializeForFirestore(crossword)
+  // Strip caller-supplied ownership fields — always use current auth user
+  delete serialized.userId
+  delete serialized.userEmail
+  delete serialized.userDisplayName
+  delete serialized.userPhotoURL
   await setDoc(docRef, {
-    ...serializeForFirestore(crossword),
+    ...serialized,
     updatedAt: Timestamp.now(),
-    // Preserve ownership — always stamp from current auth user if caller didn't provide
-    userId: crossword.userId || user?.uid,
-    userEmail: crossword.userEmail || user?.email,
-    userDisplayName: crossword.userDisplayName || user?.displayName || undefined,
-    userPhotoURL: crossword.userPhotoURL || user?.photoURL || undefined,
+    userId: user?.uid,
+    userEmail: user?.email,
+    userDisplayName: user?.displayName || undefined,
+    userPhotoURL: user?.photoURL || undefined,
   })
 }
 

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -140,27 +140,6 @@ export async function archiveCrossword(id: string): Promise<void> {
   await updateCrossword(id, { status: "archived" })
 }
 
-/** One-time repair: patch documents missing userId with current user */
-export async function repairMissingUserIds(): Promise<number> {
-  const user = auth.currentUser
-  if (!user) return 0
-  const snapshot = await getDocs(collection(db, COLLECTION))
-  let fixed = 0
-  for (const d of snapshot.docs) {
-    const data = d.data()
-    if (!data.userId) {
-      await updateDoc(doc(db, COLLECTION, d.id), {
-        userId: user.uid,
-        userEmail: user.email,
-        userDisplayName: user.displayName || undefined,
-        userPhotoURL: user.photoURL || undefined,
-      })
-      fixed++
-    }
-  }
-  return fixed
-}
-
 /** Fetch archived crosswords for review before deletion. Admin sees all, regular user sees own. */
 export async function getArchivedCrosswords(isAdmin = false): Promise<Crossword[]> {
   const user = auth.currentUser

--- a/src/lib/print-crossword.ts
+++ b/src/lib/print-crossword.ts
@@ -1,5 +1,12 @@
 import type { Crossword } from "@/types/crossword"
 
+/** Escape user content for safe HTML interpolation (prevent XSS) */
+function escapeHtml(s: string): string {
+  const div = document.createElement("div")
+  div.textContent = s
+  return div.innerHTML
+}
+
 interface PrintOptions {
   separateClues?: boolean
   largeFont?: boolean
@@ -149,7 +156,7 @@ export function openPrintWindow(crossword: Crossword, options: PrintOptions = {}
   }
 
   const subParts: string[] = []
-  if (description) subParts.push(description)
+  if (description) subParts.push(escapeHtml(description))
   if (updatedAt) subParts.push(`שונה לאחרונה: ${fmtDate(updatedAt)}`)
   const sublineHtml = subParts.length > 0
     ? `<div class="subline">${subParts.join("  ·  ")}</div>`
@@ -158,7 +165,7 @@ export function openPrintWindow(crossword: Crossword, options: PrintOptions = {}
   // Build clues as a flat list of items, then split into two flowing columns
   // Build flat clues HTML — CSS columns will handle the 2-column flow
   const renderClueItems = (clues: typeof clues_across) =>
-    clues.map((c) => `<div class="clue"><b>${c.number}. ${c.clue} <span dir="ltr" style="white-space:nowrap">${c.answerLength.replace(/,(?!\s)/g, ", ")}</span></b></div>`).join("")
+    clues.map((c) => `<div class="clue"><b>${c.number}. ${escapeHtml(c.clue)} <span dir="ltr" style="white-space:nowrap">${escapeHtml(c.answerLength.replace(/,(?!\s)/g, ", "))}</span></b></div>`).join("")
 
 
   // When separateClues is true, grid fills the page and clues go on page 2
@@ -178,7 +185,7 @@ export function openPrintWindow(crossword: Crossword, options: PrintOptions = {}
   }
 
   const cluesSection = `<div class="clues${separateClues ? " clues-page" : ""}">
-    ${separateClues ? `<h1>${title || ""}</h1>` : ""}
+    ${separateClues ? `<h1>${escapeHtml(title || "")}</h1>` : ""}
     <div class="clues-grid">
       <div class="clues-col">
         <h3>מאוזן</h3>
@@ -195,7 +202,7 @@ export function openPrintWindow(crossword: Crossword, options: PrintOptions = {}
 <html lang="he" dir="rtl">
 <head>
   <meta charset="UTF-8">
-  <title>${title || "תשבץ"}</title>
+  <title>${escapeHtml(title || "תשבץ")}</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre:wght@400;700&family=Heebo:wght@400;500;600&display=swap');
     @page { size: A4; margin: 12mm; }
@@ -302,7 +309,7 @@ export function openPrintWindow(crossword: Crossword, options: PrintOptions = {}
   </style>
 </head>
 <body>
-  <h1>${title || ""}</h1>
+  <h1>${escapeHtml(title || "")}</h1>
   ${sublineHtml}
   <div class="grid-container">
     <table class="grid">${gridHtml}</table>

--- a/src/lib/print-crossword.ts
+++ b/src/lib/print-crossword.ts
@@ -134,10 +134,10 @@ export function openPrintWindow(crossword: Crossword, options: PrintOptions = {}
           (d) => d.starty === r + 1 && d.startx === c + 1
         )
         const label = word?.position
-        const letter = isHighlighted && cell.letter ? cell.letter : ""
+        const letter = isHighlighted && cell.letter ? escapeHtml(cell.letter) : ""
         gridHtml += `<td class="cell${isHighlighted ? " hint" : ""}">
           ${letter}
-          ${label != null ? `<span class="num">${label}</span>` : ""}
+          ${label != null ? `<span class="num">${escapeHtml(String(label))}</span>` : ""}
         </td>`
       }
     }
@@ -202,6 +202,7 @@ export function openPrintWindow(crossword: Crossword, options: PrintOptions = {}
 <html lang="he" dir="rtl">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'unsafe-inline';">
   <title>${escapeHtml(title || "תשבץ")}</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre:wght@400;700&family=Heebo:wght@400;500;600&display=swap');

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -411,6 +411,7 @@ export default function EditorPage() {
         layout_result: genResult?.layout_result || [],
         layout_rows: genResult?.rows || 0,
         layout_cols: genResult?.cols || 0,
+        createdAt: existingCrossword?.createdAt,
         userId: existingCrossword?.userId,
         userEmail: existingCrossword?.userEmail,
         userDisplayName: existingCrossword?.userDisplayName,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import sri from 'vite-plugin-sri-gen'
 import path from 'path'
 import { execSync } from 'child_process'
 
@@ -9,7 +10,7 @@ const gitDate = execSync('git log -1 --format=%cI').toString().trim()
 
 export default defineConfig({
   base: '/',
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), sri()],
   define: {
     __GIT_SHA__: JSON.stringify(gitSha),
     __GIT_DATE__: JSON.stringify(gitDate),


### PR DESCRIPTION
## Summary
- **H1 fix**: Escape `cell.letter` and position `label` in print function — residual stored XSS missed in V1. Add CSP meta tag to print window (was running with zero CSP)
- **H2 fix**: Add `firestore.rules` + `firebase.json` to version control
- **M2 fix**: Add `userId` preservation check to Firestore update rule (prevents ownership transfer/orphaning)
- **M3 fix**: Preserve `createdAt` in auto-save (`setDoc` was silently dropping it)
- **M4 fix**: Remove `ws://localhost:*` from production CSP
- **M5 fix**: Remove dead code `repairMissingUserIds()`
- **L2 fix**: Expand `.gitignore` to cover all `.env` patterns
- Full V2 audit report appended to `SECURITY-AUDIT.md`

## Manual step after merge
Deploy the updated Firestore rules to Firebase Console (paste `firestore.rules` contents, or run `firebase deploy --only firestore:rules` locally). The key change is the `userId` preservation check on updates.

## Test plan
- [ ] `npm run build` passes
- [ ] Create/edit a crossword — auto-save works
- [ ] Print a crossword — grid renders correctly, highlighted cells show letters
- [ ] Deploy updated Firestore rules to Firebase Console
- [ ] Verify auto-save still works after rule deployment (userId preservation check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)